### PR TITLE
Fix sha1 function name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 # These are the specifications of the toolchain
 CC		:= gcc
 CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated
-CPPFLAGS	:= -D_BSD_SOURCE -D$(OS) $(WHIRLPOOL)
+CPPFLAGS	:= -D_DEFAULT_SOURCE -D$(OS) $(WHIRLPOOL)
 LDFLAGS		:= -lssl -lcrypto
 
 BIN_MAIN	:= hash_extender

--- a/hash_extender_engine.c
+++ b/hash_extender_engine.c
@@ -404,12 +404,12 @@ static void sha_hash(uint8_t *data, uint64_t length, uint8_t *buffer, uint8_t *s
   uint64_t i;
 
   SHA_CTX c;
-  SHA_Init(&c);
+  SHA1_Init(&c);
 
   if(state)
   {
     for(i = 0; i < state_size; i++)
-      SHA_Update(&c, "A", 1);
+      SHA1_Update(&c, "A", 1);
 
     c.h0 = htobe32(((int*)state)[0]);
     c.h1 = htobe32(((int*)state)[1]);
@@ -418,8 +418,8 @@ static void sha_hash(uint8_t *data, uint64_t length, uint8_t *buffer, uint8_t *s
     c.h4 = htobe32(((int*)state)[4]);
   }
 
-  SHA_Update(&c, data, length);
-  SHA_Final(buffer, &c);
+  SHA1_Update(&c, data, length);
+  SHA1_Final(buffer, &c);
 }
 
 static void sha1_hash(uint8_t *data, uint64_t length, uint8_t *buffer, uint8_t *state, uint64_t state_size)


### PR DESCRIPTION
In association with the change of _BSD_SOURCE in the Makefile (another pull resquest already exist on this point) : 

`sed -i -e 's/_BSD_SOURCE/_DEFAULT_SOURCE/' Makefile`

This patch permit to compile hash_extender with openssl 1.1.0e-1 : The fuction name changes from sha_update to sha1_update (idem for sha_init and sha_final).

Regards,
fraf