### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 
 # These are the specifications of the toolchain
 CC		:= gcc
-CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated
+CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated-declarations
 CPPFLAGS	:= -D_DEFAULT_SOURCE -D$(OS) $(WHIRLPOOL)
 ifeq ($(OS),DARWIN)
     LDFLAGS		:= -lssl -lcrypto -L/usr/local/opt/openssl/lib/


### PR DESCRIPTION
I have made a modification to the Makefile to handle deprecated function warnings in OpenSSL 3.0 and later versions. The modification includes adding the -Wno-deprecated-declarations option to the compilation flags (CFLAGS).

By adding this option, it disables the warnings related to deprecated functions, allowing for error-free compilation within the context of OpenSSL 3.0 and newer versions.