### PR TITLE
Add OpenSSL 1.1.1 as submodule for legacy API support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            artifact_name: hash_extender
+            asset_name: hash_extender-linux-x86_64
+          - os: windows
+            artifact_name: hash_extender.exe
+            asset_name: hash_extender-windows-x86_64.exe
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Setup for Windows cross-compilation
+        if: matrix.os == 'windows'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mingw-w64 gcc-mingw-w64 mingw-w64-tools
+
+      - name: Build for Linux
+        if: matrix.os == 'linux'
+        run: |
+          make
+
+      - name: Build for Windows
+        if: matrix.os == 'windows'
+        run: |
+          make CC=x86_64-w64-mingw32-gcc
+
+      - name: Rename artifact to asset_name
+        run: mv ${{ matrix.artifact_name }} ${{ matrix.asset_name }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.asset_name }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: List downloaded files (debug)
+        run: ls -R
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            hash_extender-linux-x86_64/hash_extender-linux-x86_64
+            hash_extender-windows-x86_64.exe/hash_extender-windows-x86_64.exe
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 hash_extender_test
 hash_extender
 
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "openssl"]
+	path = openssl
+	url = https://github.com/openssl/openssl.git
+	branch = OpenSSL_1_1_1-stable

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(BIN_TEST): $(OPENSSL_INSTALL)/lib/libssl.a $(OBJS_TEST)
 	@echo [LD] $@
 	@$(CC) $(CFLAGS) -o $(BIN_TEST) $(OBJS_TEST) $(LDFLAGS)
 
-%.o: %.c
+%.o: %.c | $(OPENSSL_INSTALL)/lib/libssl.a
 	@echo [CC] $@
 	@$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 CC		:= gcc
 CFLAGS		:= -std=c99 -g -oS -Wall -Werror -Wno-deprecated-declarations
 CPPFLAGS	:= -I$(INCLUDE_OPENSSL) -D_DEFAULT_SOURCE
-LDFLAGS		:= -L$(LIB_OPENSSL) -lssl -lcrypto $(if $(findstring MINGW,$(OS)),-lws2_32) $(if $(findstring MINGW,$(OS)),-lcrypt32)
+LDFLAGS		:= -L$(LIB_OPENSSL) -lssl -lcrypto $(if $(findstring mingw,$(shell $(CC) -dumpmachine)),-lws2_32) $(if $(findstring mingw,$(shell $(CC) -dumpmachine)),-lcrypt32)
 
 BIN_MAIN	:= hash_extender
 BIN_TEST	:= hash_extender_test
@@ -34,7 +34,7 @@ $(OPENSSL_SRC)/Makefile:
 	@echo "Downloading and preparing OpenSSL source..."
 	@git submodule update --init --depth 1 --single-branch
 	@cd $(OPENSSL_SRC) && \
-		$(if $(findstring MINGW,$(OS)),/usr/bin/perl Configure mingw64 "--prefix=$(shell cygpath -m $(OPENSSL_INSTALL))" no-shared no-dso,./config --prefix=$(OPENSSL_INSTALL) no-shared no-dso)
+		$(if $(findstring mingw,$(shell $(CC) -dumpmachine)),/usr/bin/perl Configure $(if $(shell which x86_64-w64-mingw32-gcc),--cross-compile-prefix=x86_64-w64-mingw32-,) mingw64 "--prefix=$(if $(shell which cygpath),$(shell cygpath -m $(OPENSSL_INSTALL)),$(OPENSSL_INSTALL))" no-shared no-dso,./config --prefix=$(OPENSSL_INSTALL) no-shared no-dso)
 
 $(BIN_MAIN): $(OPENSSL_INSTALL)/lib/libssl.a $(OBJS_MAIN)
 	@echo [LD] $@

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(OPENSSL_SRC)/Makefile:
 	@echo "Downloading and preparing OpenSSL source..."
 	@git submodule update --init
 	@cd $(OPENSSL_SRC) && \
-		./config --prefix=$(OPENSSL_INSTALL) no-shared no-dso
+		$(if $(findstring MINGW,$(OS)),/usr/bin/perl Configure mingw64 "--prefix=$(shell cygpath -m $(OPENSSL_INSTALL))" no-shared no-dso,./config --prefix=$(OPENSSL_INSTALL) no-shared no-dso)
 
 $(BIN_MAIN): $(OPENSSL_INSTALL)/lib/libssl.a $(OBJS_MAIN)
 	@echo [LD] $@

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 # These are the specifications of the toolchain
 CC		:= gcc
 CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated-declarations
-CPPFLAGS	:= -D_DEFAULT_SOURCE -D$(OS) -I$(INCLUDE_OPENSSL)
-LDFLAGS		:= -lssl -lcrypto -L$(LIB_OPENSSL)
+CPPFLAGS	:= -I$(INCLUDE_OPENSSL) -D_DEFAULT_SOURCE -D$(OS)
+LDFLAGS		:= -L$(LIB_OPENSSL) -lssl -lcrypto
 
 BIN_MAIN	:= hash_extender
 BIN_TEST	:= hash_extender_test

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: $(OPENSSL_INSTALL)/lib/libssl.a $(BINS)
 # OpenSSL build and install
 $(OPENSSL_INSTALL)/lib/libssl.a: $(OPENSSL_SRC)/Makefile
 	@echo "Building OpenSSL..."
-	@cd $(OPENSSL_SRC) && \
+	+@cd $(OPENSSL_SRC) && \
 		make && make install_sw
 
 $(OPENSSL_SRC)/Makefile:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ $(OPENSSL_INSTALL)/lib/libssl.a: $(OPENSSL_SRC)/Makefile
 
 $(OPENSSL_SRC)/Makefile:
 	@echo "Downloading and preparing OpenSSL source..."
-	@git submodule update --init
+	@git submodule update --init --depth 1 --single-branch
 	@cd $(OPENSSL_SRC) && \
 		$(if $(findstring MINGW,$(OS)),/usr/bin/perl Configure mingw64 "--prefix=$(shell cygpath -m $(OPENSSL_INSTALL))" no-shared no-dso,./config --prefix=$(OPENSSL_INSTALL) no-shared no-dso)
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(BIN_TEST): $(OPENSSL_INSTALL)/lib/libssl.a $(OBJS_TEST)
 	@echo [LD] $@
 	@$(CC) $(CFLAGS) -o $(BIN_TEST) $(OBJS_TEST) $(LDFLAGS)
 
-%.o: $(OPENSSL_INSTALL)/lib/libssl.a %.c
+%.o: %.c
 	@echo [CC] $@
 	@$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OPENSSL_SRC := $(CURDIR)/openssl
 OPENSSL_BUILD := $(OPENSSL_SRC)/build
-OPENSSL_INSTALL := $(OPENSSL_SRC)/install
+OPENSSL_INSTALL := $(OPENSSL_SRC)/install_dir
 INCLUDE_OPENSSL := $(OPENSSL_INSTALL)/include
 LIB_OPENSSL := $(OPENSSL_INSTALL)/lib
 
@@ -58,3 +58,4 @@ clean:
 	@echo [RM] OpenSSL build and install
 	@make -C $(OPENSSL_SRC) clean
 	@rm -rf $(OPENSSL_BUILD) $(OPENSSL_INSTALL)
+	@rm $(OPENSSL_SRC)/Makefile $(OPENSSL_SRC)/configdata.pm

--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,15 @@ $(OPENSSL_SRC)/Makefile:
 	@cd $(OPENSSL_SRC) && \
 		./config --prefix=$(OPENSSL_INSTALL) no-shared no-dso
 
-$(BIN_MAIN): $(OBJS_MAIN) $(OPENSSL_INSTALL)/lib/libssl.a
+$(BIN_MAIN): $(OPENSSL_INSTALL)/lib/libssl.a $(OBJS_MAIN)
 	@echo [LD] $@
 	@$(CC) $(CFLAGS) -o $(BIN_MAIN) $(OBJS_MAIN) $(LDFLAGS)
 
-$(BIN_TEST): $(OBJS_TEST) $(OPENSSL_INSTALL)/lib/libssl.a
+$(BIN_TEST): $(OPENSSL_INSTALL)/lib/libssl.a $(OBJS_TEST)
 	@echo [LD] $@
 	@$(CC) $(CFLAGS) -o $(BIN_TEST) $(OBJS_TEST) $(LDFLAGS)
 
-%.o: %.c
+%.o: $(OPENSSL_INSTALL)/lib/libssl.a %.c
 	@echo [CC] $@
 	@$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 # These are the specifications of the toolchain
 CC		:= gcc
 CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated-declarations
-CPPFLAGS	:= -I$(INCLUDE_OPENSSL) -D_DEFAULT_SOURCE -D$(OS)
+CPPFLAGS	:= -I$(INCLUDE_OPENSSL) -D_DEFAULT_SOURCE
 LDFLAGS		:= -L$(LIB_OPENSSL) -lssl -lcrypto
 
 BIN_MAIN	:= hash_extender

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 
 # These are the specifications of the toolchain
 CC		:= gcc
-CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated-declarations
+CFLAGS		:= -std=c99 -g -oS -Wall -Werror -Wno-deprecated-declarations
 CPPFLAGS	:= -I$(INCLUDE_OPENSSL) -D_DEFAULT_SOURCE
-LDFLAGS		:= -L$(LIB_OPENSSL) -lssl -lcrypto
+LDFLAGS		:= -L$(LIB_OPENSSL) -lssl -lcrypto $(if $(findstring MINGW,$(OS)),-lws2_32) $(if $(findstring MINGW,$(OS)),-lcrypt32)
 
 BIN_MAIN	:= hash_extender
 BIN_TEST	:= hash_extender_test

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Now I'm gonna release the tool, and hope I didn't totally miss a good tool that 
 - SHA-256
 - SHA-512
 - WHIRLPOOL
+- SM3
 
 I'm more than happy to extend this to cover other hashing algorithms as well, provided they are "vulnerable" to this attack -- MD2, SHA-224, and SHA-384 are not. Please contact me if you have other candidates and I'll add them ASAP!
 

--- a/buffer.c
+++ b/buffer.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h> /* For htons/htonl. */
 #else
 #include <arpa/inet.h> /* For htons/htonl. */

--- a/hash_extender.c
+++ b/hash_extender.c
@@ -1,5 +1,21 @@
 #include <ctype.h>
-#include <err.h>
+
+#ifdef _WIN32
+  #define err(eval, fmt, ...) \
+      do { fprintf(stderr, fmt ": %s\n", ##__VA_ARGS__, strerror(errno)); exit(eval); } while (0)
+
+  #define errx(eval, fmt, ...) \
+      do { fprintf(stderr, fmt "\n", ##__VA_ARGS__); exit(eval); } while (0)
+
+  #define warn(fmt, ...) \
+      fprintf(stderr, fmt ": %s\n", ##__VA_ARGS__, strerror(errno))
+
+  #define warnx(fmt, ...) \
+      fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+#else
+  #include <err.h>
+#endif
+
 #include <getopt.h>
 
 #include "buffer.h"

--- a/hash_extender_engine.c
+++ b/hash_extender_engine.c
@@ -1,6 +1,6 @@
 #include <arpa/inet.h>
 
-#ifdef FREEBSD
+#ifdef __FREEBSD__
 #include <sys/endian.h>
 #elif defined(__APPLE__)
   #include <libkern/OSByteOrder.h>
@@ -29,9 +29,7 @@
 #include "openssl/sha.h"
 #include "openssl/evp.h"
 #include "tiger.h"
-#ifndef DISABLE_WHIRLPOOL
 #include "openssl/whrlpool.h"
-#endif
 
 #include "hash_extender_engine.h"
 

--- a/hash_extender_engine.c
+++ b/hash_extender_engine.c
@@ -23,17 +23,14 @@
 #include <endian.h>
 #endif
 
-#include <openssl/md4.h>
-#include <openssl/md5.h>
-#include <openssl/ripemd.h>
-#include <openssl/sha.h>
-#include <openssl/sha.h>
-#include <openssl/sha.h>
-#include <openssl/sha.h>
-#include <openssl/evp.h>
+#include "openssl/md4.h"
+#include "openssl/md5.h"
+#include "openssl/ripemd.h"
+#include "openssl/sha.h"
+#include "openssl/evp.h"
 #include "tiger.h"
 #ifndef DISABLE_WHIRLPOOL
-#include <openssl/whrlpool.h>
+#include "openssl/whrlpool.h"
 #endif
 
 #include "hash_extender_engine.h"

--- a/hash_extender_engine.c
+++ b/hash_extender_engine.c
@@ -1,7 +1,11 @@
-#include <arpa/inet.h>
+#ifdef _WIN32
+  #include <winsock2.h> /* For htons/htonl. */
+#else
+  #include <arpa/inet.h> /* For htons/htonl. */
+#endif
 
 #ifdef __FREEBSD__
-#include <sys/endian.h>
+  #include <sys/endian.h>
 #elif defined(__APPLE__)
   #include <libkern/OSByteOrder.h>
 
@@ -19,6 +23,39 @@
   #define htole64(x) OSSwapHostToLittleInt64(x)
   #define be64toh(x) OSSwapBigToHostInt64(x)
   #define le64toh(x) OSSwapLittleToHostInt64(x)
+#elif _WIN32
+  // for htons, htonl, etc.
+  #include <winsock2.h> 
+  // for _byteswap_uint64
+  #include <stdlib.h>   
+  // for uint64_t
+  #include <stdint.h>   
+
+  // 16-bit
+  #define htobe16(x) htons(x)
+  #define htole16(x) (x)
+  #define be16toh(x) ntohs(x)
+  #define le16toh(x) (x)
+
+  // 32-bit
+  #define htobe32(x) htonl(x)
+  #define htole32(x) (x)
+  #define be32toh(x) ntohl(x)
+  #define le32toh(x) (x)
+
+  // 64-bit (Windows doesn't define htonll/ntohll, so define manually)
+  #if defined(_MSC_VER)
+    #define htobe64(x) _byteswap_uint64(x)
+    #define be64toh(x) _byteswap_uint64(x)
+  #else
+    static uint64_t htobe64(uint64_t x) {
+        return ((uint64_t)htonl((uint32_t)(x >> 32)) |
+                ((uint64_t)htonl((uint32_t)(x & 0xFFFFFFFF)) << 32));
+    }
+#endif
+#define htole64(x) (x)
+#define le64toh(x) (x)
+
 #else
 #include <endian.h>
 #endif

--- a/util.h
+++ b/util.h
@@ -1,7 +1,22 @@
 #ifndef _UTIL_H_
 #define _UTIL_H_
 
+#ifdef _WIN32
+#define err(eval, fmt, ...) \
+    do { fprintf(stderr, fmt ": %s\n", ##__VA_ARGS__, strerror(errno)); exit(eval); } while (0)
+
+#define errx(eval, fmt, ...) \
+    do { fprintf(stderr, fmt "\n", ##__VA_ARGS__); exit(eval); } while (0)
+
+#define warn(fmt, ...) \
+    fprintf(stderr, fmt ": %s\n", ##__VA_ARGS__, strerror(errno))
+
+#define warnx(fmt, ...) \
+    fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+#else
 #include <err.h>
+#endif
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
This PR adds OpenSSL 1.1.1 as a Git submodule and updates the build process to ensure compatibility with APIs that have been removed or deprecated in OpenSSL 3.0+, and adds support for MINGW64 in msys2.

# Changes Made
- Added OpenSSL 1.1.1 as a submodule under folder `openssl`
- Modified Makefile to:
  - Build OpenSSL 1.1.1 as part of the project
  - Link against the custom-built OpenSSL instead of the system one
- Support MINGW64 in Windows


# Reason
The project relies on several OpenSSL APIs that were removed in 3.0+, such as EVP_MD_CTX_md_data(). This causes the program to crash with a segmentation fault during SM3 tests when linked against the system-installed OpenSSL 3.0+, and similar functionality has not been made available in OpenSSL 3.0+.